### PR TITLE
fix(session/container): emails with special characters can now be used

### DIFF
--- a/src/lib/session/index.ts
+++ b/src/lib/session/index.ts
@@ -8,6 +8,7 @@ import { getAuthSession } from "../auth";
 import { revalidatePath } from "next/cache";
 import { consola } from "consola";
 const getRandomNumber = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
+const encodeEmailLocal = (email: string) => Array.from(email).map(char => /[a-zA-Z0-9_.-]/.test(char) ? char : char.charCodeAt(0)).join("");
 /**
  * Creates a new Stardust session
  * @param Image Docker image to use for making the session
@@ -32,7 +33,7 @@ async function createSession(Image: string) {
 		}
 		const container = await docker
 			.createContainer({
-				name: `stardust-${Date.now()}-${userSession.user.email?.split("@")[0]}`,
+				name: `stardust-${Date.now()}-${encodeEmailLocal(userSession.user.email?.split("@")[0])}`,
 				Image,
 				HostConfig: {
 					PortBindings: {

--- a/src/lib/session/index.ts
+++ b/src/lib/session/index.ts
@@ -8,7 +8,10 @@ import { getAuthSession } from "../auth";
 import { revalidatePath } from "next/cache";
 import { consola } from "consola";
 const getRandomNumber = (min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min;
-const encodeEmailLocal = (email: string) => Array.from(email).map(char => /[a-zA-Z0-9_.-]/.test(char) ? char : char.charCodeAt(0)).join("");
+const encodeEmailLocal = (email: string) =>
+	Array.from(email)
+		.map((char) => (/[a-zA-Z0-9_.-]/.test(char) ? char : char.charCodeAt(0)))
+		.join("");
 /**
  * Creates a new Stardust session
  * @param Image Docker image to use for making the session
@@ -33,7 +36,7 @@ async function createSession(Image: string) {
 		}
 		const container = await docker
 			.createContainer({
-				name: `stardust-${Date.now()}-${encodeEmailLocal(userSession.user.email?.split("@")[0])}`,
+				name: `stardust-${Date.now()}-${encodeEmailLocal((userSession.user?.email as string).split("@")[0])}`,
 				Image,
 				HostConfig: {
 					PortBindings: {


### PR DESCRIPTION
Fixes #6

This is solved by passing the email localname through `encodeEmailLocal`, which replaces special symbols (any symbol other than `._-`) with the respective character's codepoint.

> [!warning]
> I have not tested this, neither have I ran any CD formatting, lints, or checks. It would be great if someone could do so.

Related: @IncognitoTGT
