### PR TITLE
fix: add docker as dev shell package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
               postgresql_16
               libpqxx
               jq
+              docker
             ];
           };
       }


### PR DESCRIPTION
https://stardust-docs.vercel.app/docs/install#setup describes using docker to create the network and run postgres, but the flake.nix file doesn't have docker added as a package